### PR TITLE
Fixed a bug that could crash the kernel, and limit the value of the s…

### DIFF
--- a/target/linux/generic/pending-5.15/613-netfilter_optional_tcp_window_check.patch
+++ b/target/linux/generic/pending-5.15/613-netfilter_optional_tcp_window_check.patch
@@ -44,9 +44,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	[NF_SYSCTL_CT_PROTO_TCP_NO_WINDOW_CHECK] = {
 +		.procname       = "nf_conntrack_tcp_no_window_check",
 +		.data           = &init_net.ct.sysctl_no_window_check,
-+		.maxlen         = sizeof(unsigned int),
++		.maxlen         = sizeof(u8),
 +		.mode           = 0644,
-+		.proc_handler   = proc_dointvec,
++		.proc_handler	= proc_dou8vec_minmax,
++		.extra1 	= SYSCTL_ZERO,
++		.extra2 	= SYSCTL_ONE,
 +	},
  	{}
  };


### PR DESCRIPTION
…ysctl variable: net.netfilter.nf_conntrack_tcp_no_window_check to 0 or 1. (#8967)

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
