### PR TITLE
Fix 613-netfilter_optional_tcp_window_check.patch (#8970)

### DIFF
--- a/target/linux/generic/pending-5.15/613-netfilter_optional_tcp_window_check.patch
+++ b/target/linux/generic/pending-5.15/613-netfilter_optional_tcp_window_check.patch
@@ -37,7 +37,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	__NF_SYSCTL_CT_LAST_SYSCTL,
  };
  
-@@ -1026,6 +1027,13 @@ static struct ctl_table nf_ct_sysctl_tab
+@@ -1026,6 +1027,15 @@ static struct ctl_table nf_ct_sysctl_table[] = {
  		.proc_handler	= nf_hooks_lwtunnel_sysctl_handler,
  	},
  #endif
@@ -53,7 +53,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	{}
  };
  
-@@ -1153,6 +1161,7 @@ static int nf_conntrack_standalone_init_
+@@ -1153,6 +1163,7 @@ static int nf_conntrack_standalone_init_sysctl(struct net *net)
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
  	table[NF_SYSCTL_CT_EVENTS].data = &net->ct.sysctl_events;
  #endif
@@ -61,7 +61,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #ifdef CONFIG_NF_CONNTRACK_TIMESTAMP
  	table[NF_SYSCTL_CT_TIMESTAMP].data = &net->ct.sysctl_tstamp;
  #endif
-@@ -1222,6 +1231,7 @@ static int nf_conntrack_pernet_init(stru
+@@ -1222,6 +1233,7 @@ static int nf_conntrack_pernet_init(struct net *net)
  	int ret;
  
  	net->ct.sysctl_checksum = 1;


### PR DESCRIPTION
* Fixed a bug that could crash the kernel, and limit the value of the sysctl variable: net.netfilter.nf_conntrack_tcp_no_window_check to 0 or 1.

* Fix pending-5.15/613-netfilter_optional_tcp_window_check.patch

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
